### PR TITLE
Fixed bug: dataset parameter is handled incorrectly when mode is "spot,link".

### DIFF
--- a/src/main/java/org/elinker/core/rest/FremeNerEnrichment.java
+++ b/src/main/java/org/elinker/core/rest/FremeNerEnrichment.java
@@ -197,7 +197,7 @@ public class FremeNerEnrichment extends BaseRestController {
 			rdf = fremeNer.spotClassify(plaintext, language, "TTL",
 					nifParameters.getPrefix());
 		}else if(rMode.contains(MODE_SPOT) && rMode.contains(MODE_LINK)){
-			rdf = fremeNer.spotLink(plaintext, language, datasetKey, "TTL",
+			rdf = fremeNer.spotLink(plaintext, language, dataset, "TTL",
 					nifParameters.getPrefix(), numLinks, domain, types);
 		}else if(rMode.contains(MODE_SPOT)){
 			rdf = fremeNer.spot(plaintext, language, "TTL",


### PR DESCRIPTION
The parameter 'datasetKey' is used instead of 'dataset' (only in this mode combination).